### PR TITLE
bug; boolean value false not resolved in template. Solved.

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function expand(options) {
 
     var val = utils.get(data, prop);
     if (dot) val += '.';
-    if (val) return val;
+    if (val || val == false) return val;
 
     // if no `.`, return
     var idx = prop.indexOf('.');

--- a/index.js
+++ b/index.js
@@ -107,7 +107,9 @@ function expand(options) {
 
     var val = utils.get(data, prop);
     if (dot) val += '.';
-    if (val || val == false) return val;
+    if (typeof val !== 'undefined') {
+      return val;
+    }
 
     // if no `.`, return
     var idx = prop.indexOf('.');

--- a/test.js
+++ b/test.js
@@ -219,6 +219,10 @@ describe('expand', function() {
     assert.deepEqual(actual.a.c, 'ddd/eee/FOO');
   });
 
+  it('should process boolean in data.', function() {
+    assert.strictEqual(expand('<%= a %> <%= b %>', {a: false, b: true}), 'false true');
+  });
+
   it('should process nested templates recursively', function() {
     var actual = expand('<%= c.e %>', {
       a: 1,


### PR DESCRIPTION
### Bug :

In case data has a key which value is boolean false, in that case it'll not resolve the template.
- e.g. 

**Template :** <%= a %>
**Data :** {a: false}
**Expected Result :** false
**Actual Result :** <%= a %>

p.s. It was working for boolean data `true`
